### PR TITLE
build: Update actions versions and push test image

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -62,7 +62,7 @@ jobs:
       id-token: write # required for signing with cosign
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -73,7 +73,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           push: true

--- a/.github/workflows/test_image.yaml
+++ b/.github/workflows/test_image.yaml
@@ -26,7 +26,7 @@ jobs:
       contents: read # required for actions/checkout
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.sha }} # required for better experience using pre-releases
           fetch-depth: "0" # Required due to the way Git works, without it this action won't be able to find any or the correct tags
@@ -38,13 +38,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Docker image
+      - name: Build Docker image and test push action
         id: build-to-test
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           load: true
-          push: false
+          push: true
           tags: |
             ghcr.io/sysdiglabs/sysdig-mcp-server:test
 


### PR DESCRIPTION
Update the test_image workflow to push a test image to the registry, so we make sure the push action works as expected before releasing the latest version. 
