### PR TITLE
Adding test with MCP client for tool response

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # required for actions/checkout
+    env:
+      SYSDIG_MCP_API_HOST: ${{ vars.SYSDIG_MCP_API_HOST }}
+      SYSDIG_MCP_TRANSPORT: ${{ vars.SYSDIG_MCP_TRANSPORT }}
+      SYSDIG_MCP_API_SECURE_TOKEN: ${{ secrets.SYSDIG_MCP_API_SECURE_TOKEN }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -43,5 +47,10 @@ jobs:
       - name: Run ruff
         run: make lint
 
-      - name: Run Unit Tests
-        run: make test
+      - name: Start MCP server in the background
+        run: |
+          make start-server-background
+
+      - name: Run MCP client
+        run: |
+          make test

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,7 @@ test:
 
 test-coverage:
 	uv run pytest --cov=. --cov-report=xml
+
+start-server-background:
+	uv run main.py &
+	sleep 5  # Wait for the server to start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ sysdig-mcp-server = "main:main"
 dev-dependencies = [
     "pytest-cov~=6.2",
     "pytest~=8.4",
-    "ruff~=0.12.1",
+    "ruff~=0.12",
+    "pytest-asyncio~=1.2",
 ]
 
 [build-system]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,8 +47,8 @@ def mock_creds():
     """
     Fixture to set up mocked credentials.
     """
-    os.environ["SYSDIG_MCP_API_SECURE_TOKEN"] = "mocked_token"
-    os.environ["SYSDIG_MCP_API_HOST"] = "https://us2.app.sysdig.com"
+    os.environ["SYSDIG_MCP_API_SECURE_TOKEN"] = os.environ.get("SYSDIG_MCP_API_SECURE_TOKEN", "mocked_token")
+    os.environ["SYSDIG_MCP_API_HOST"] = os.environ.get("SYSDIG_MCP_API_HOST", "https://us2.app.sysdig.com")
 
 
 def mock_app_config() -> AppConfig:

--- a/tests/tools_test.py
+++ b/tests/tools_test.py
@@ -1,0 +1,32 @@
+"""
+This is a simple test client to verify the MCP server is running and responding to requests.
+"""
+
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+import os
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_list_runtime_events():
+    """
+    Test the list_runtime_events tool of the MCP server.
+    This function initializes a client, calls the list_runtime_events tool,
+    and prints the status code and total number of runtime events retrieved.
+    """
+
+    async with Client(
+        transport=StreamableHttpTransport(
+            url="http://localhost:8080/sysdig-mcp-server/mcp",
+            headers={"X-Sysdig-Token": f"Bearer {os.getenv('SYSDIG_MCP_API_SECURE_TOKEN')}"},
+        ),
+        auth="oauth",  # Use "oauth" if the server is configured with OAuth authentication, otherwise use None
+    ) as client:
+        tool_name = "list_runtime_events"
+        result = await client.call_tool(tool_name)
+        assert result.structured_content.get("status_code") == 200
+        print(
+            f"Tool {tool_name} completed with status code: {result.structured_content.get('status_code')}"
+            f" with a total of: {result.data.get('results', {}).get('page', {}).get('total', 0)} runtime events."
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -993,6 +993,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119, upload-time = "2025-09-12T07:33:53.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095, upload-time = "2025-09-12T07:33:52.639Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "6.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1387,6 +1400,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
@@ -1409,8 +1423,9 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = "~=8.4" },
+    { name = "pytest-asyncio", specifier = "~=1.2" },
     { name = "pytest-cov", specifier = "~=6.2" },
-    { name = "ruff", specifier = "~=0.12.1" },
+    { name = "ruff", specifier = "~=0.12" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Adding test with MCP client for tool response

## Changes

* Adding another test for an MCP client to get the response of the `list_runtime_events` tool
