### PR TITLE
chore: pin go_1_26 to nixos-25.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34,10 +34,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-25-11": {
+      "locked": {
+        "lastModified": 1778737229,
+        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-25-11": "nixpkgs-25-11"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,12 +1,14 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs-25-11.url = "github:NixOS/nixpkgs/nixos-25.11";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs =
     {
       self,
       nixpkgs,
+      nixpkgs-25-11,
       flake-utils,
     }:
     let
@@ -17,13 +19,24 @@
           else
             prev.callPackage ./package.nix { };
       };
+      useLatestGoVersion =
+        final: prev:
+        let
+          nixpkgs = import nixpkgs-25-11 { inherit (prev) system; };
+        in
+        {
+          go_1_26 = nixpkgs.go_1_26;
+        };
       flake = flake-utils.lib.eachDefaultSystem (
         system:
         let
           pkgs = import nixpkgs {
             inherit system;
             config.allowUnfree = true;
-            overlays = [ self.overlays.default ];
+            overlays = [
+              self.overlays.default
+              useLatestGoVersion
+            ];
           };
         in
         {


### PR DESCRIPTION
In nixpkgs-unstable, `go_1_26` is treated as a critical package due to the large number of reverse dependencies, so updates land slowly. `nixos-25.11` has far fewer dependents on the Go toolchain, so it tracks new Go releases much faster.

Sourcing `go_1_26` from `nixos-25.11` via overlay keeps the dev shell closer to upstream Go without bumping the rest of `nixpkgs`.