### PR TITLE
build: update dependencies, switch to prek and go-overlay

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,9 +107,9 @@ just test       # Run the unit test suite (auto-runs `go generate` first).
 just check      # A convenient alias for fmt + lint + test.
 ```
 
-### 4.2. Pre-commit Hooks
+### 4.2. Prek Hooks
 
-This repository uses **pre-commit** to automate quality checks before each commit.
+This repository uses **prek** to automate quality checks before each commit.
 The hooks are configured in `.pre-commit-config.yaml` to run `just fmt`, `just lint`, and `just test`.
 If any of the hooks fail, the commit will not be created.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -12,5 +12,5 @@
 **Problem**: Tests failing with "command not found"
 - **Solution**: Enter Nix shell with `nix develop` or `direnv allow`. All dev tools are provided by the flake.
 
-**Problem**: Pre-commit hooks not running
-- **Solution**: Run `pre-commit install` to install git hooks, then `pre-commit run -a` to test all files.
+**Problem**: Prek hooks not running
+- **Solution**: Run `prek install` to install git hooks, then `prek run -a` to test all files.

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -18,7 +34,106 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "go-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778507602,
+        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "go-overlay",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "go-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1781844949,
+        "narHash": "sha256-UyfsHNsFw1SbPXD4nkpUbrt78YP2Rg6prle6BQw0/ZA=",
+        "owner": "purpleclay",
+        "repo": "go-overlay",
+        "rev": "049f906b44c05df13cc7294c509afb42cd616fb1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "purpleclay",
+        "repo": "go-overlay",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1781607440,
         "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
@@ -34,30 +149,29 @@
         "type": "github"
       }
     },
-    "nixpkgs-25-11": {
-      "locked": {
-        "lastModified": 1781509190,
-        "narHash": "sha256-uJZs9Di8I6ciTp6jiojj0HzlNpBkud8ax5aT/O5aJkw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d6df3513510aa548c83868fd22bfddd0a8c0a0d4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-25.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "nixpkgs-25-11": "nixpkgs-25-11"
+        "go-overlay": "go-overlay",
+        "nixpkgs": "nixpkgs_2"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,10 @@
       };
       useLatestGoVersion = final: prev: {
         go_latest = final.go-bin.latestStable;
-        buildGoLatestModule = prev.buildGoLatestModule.override { go = final.go-bin.latestStable; };
+        # Use buildPackages so the Go toolchain runs on the build platform while
+        # still cross-compiling for the target (matches nixpkgs' buildGo*Module),
+        # otherwise cross builds pick the target-arch Go binary and fail to exec.
+        buildGoLatestModule = prev.buildGoLatestModule.override { go = final.buildPackages.go-bin.latestStable; };
       };
       flake = flake-utils.lib.eachDefaultSystem (
         system:

--- a/flake.nix
+++ b/flake.nix
@@ -1,14 +1,14 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nixpkgs-25-11.url = "github:NixOS/nixpkgs/nixos-25.11";
+    go-overlay.url = "github:purpleclay/go-overlay";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs =
     {
       self,
       nixpkgs,
-      nixpkgs-25-11,
+      go-overlay,
       flake-utils,
     }:
     let
@@ -19,14 +19,10 @@
           else
             prev.callPackage ./package.nix { };
       };
-      useLatestGoVersion =
-        final: prev:
-        let
-          nixpkgs = import nixpkgs-25-11 { inherit (prev) system; };
-        in
-        {
-          go_1_26 = nixpkgs.go_1_26;
-        };
+      useLatestGoVersion = final: prev: {
+        go_latest = final.go-bin.latestStable;
+        buildGoLatestModule = prev.buildGoLatestModule.override { go = final.go-bin.latestStable; };
+      };
       flake = flake-utils.lib.eachDefaultSystem (
         system:
         let
@@ -35,6 +31,7 @@
             config.allowUnfree = true;
             overlays = [
               self.overlays.default
+              go-overlay.overlays.default
               useLatestGoVersion
             ];
           };
@@ -51,19 +48,19 @@
             mkShell {
               packages = [
                 ginkgo
-                go_1_26
+                go_latest
                 govulncheck
                 gofumpt
                 golangci-lint
                 just
                 mockgen
                 nix-prefetch-docker
-                pre-commit
+                prek
                 skopeo
                 sd
               ];
               shellHook = ''
-                pre-commit install
+                prek install
               '';
             };
 

--- a/justfile
+++ b/justfile
@@ -39,7 +39,7 @@ update:
 	nix develop --command go get -u -t -v ./...
 	nix develop --command go mod tidy
 	nix develop --command just rehash-package-nix
-	nix develop --command pre-commit autoupdate
+	nix develop --command prek autoupdate
 	nix develop --command just update-base-images
 
 # Re-calculate the vendorHash from the package.nix

--- a/package.nix
+++ b/package.nix
@@ -1,5 +1,5 @@
-{ buildGo126Module, versionCheckHook }:
-buildGo126Module (finalAttrs: {
+{ buildGoLatestModule, versionCheckHook }:
+buildGoLatestModule (finalAttrs: {
   pname = "sysdig-mcp-server";
   version = "3.0.0";
   src = ./.;


### PR DESCRIPTION
Updates all dependencies, bumps the version to `2.0.2` for release, and migrates the Go toolchain source to [`go-overlay`](https://github.com/purpleclay/go-overlay).

**Why drop `nixos-25.11` for Go?**

In #84 we pinned `go_1_26` to `nixos-25.11` because there it wasn't the latest stable Go (1.25 was), so it had few reverse dependencies and got updated within hours of an upstream release.

That no longer works: `nixos-25.11` is now a frozen stable release channel, so its Go toolchain won't move forward anymore — staying on it means getting stuck on an increasingly outdated Go. `nixpkgs-unstable` isn't a fix either: there the latest-stable Go is a dependency of many packages, so a bump has to clear the whole test/rebuild pipeline before landing — typically ~3 weeks between a Go release and it being usable.

`go-overlay` removes both problems: it tracks upstream Go releases and updates within hours, independent of the nixpkgs rebuild cycle, so we always build against the current toolchain.

**Why `prek` instead of `pre-commit`?**

[`prek`](https://github.com/j178/prek) is a drop-in `pre-commit` reimplementation in Rust: same `.pre-commit-config.yaml`, no Python/virtualenv bootstrap, faster install and parallel hook execution, and a smaller on-disk footprint.
